### PR TITLE
Initial Windows support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,22 @@
 language: c
-script: make "CFLAGS=-O2 -Wall -fPIC -g -DR344_COMPAT" && make test
-addons:
-  apt:
-    packages:
-      - r-base
-      - libunwind-dev
-      - libelf-dev
+matrix:
+  include:
+    - os: linux
+      script:
+        - make "CFLAGS=-O2 -Wall -fPIC -g -DR344_COMPAT"
+        - make test
+      addons:
+        apt_packages:
+          - r-base
+          - libunwind-dev
+          - libelf-dev
+    - os: windows
+      before_install:
+        - choco install make r
+        # Rscript.exe is not in the PATH by default.
+        - export R_VERSION=`ls 'C:\Program Files\R\'`
+        - export PATH=$PATH:';C:\Program Files\R\'$R_VERSION'\bin\x64'
+        - Rscript.exe --version
+      script:
+        - make BIN=xrprof.exe LIBS="-lntdll -lpsapi -ldbghelp -lpthread -static"
+        - make BIN=xrprof.exe RSCRIPT="Rscript.exe" SUDO="" test

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,8 @@ BIN = xrprof
 BINOBJ = src/xrprof.o
 OBJ = src/cursor.o \
   src/locate.o \
-  src/memory.o
+  src/memory.o \
+  src/process.o
 SHLIB = libxrprof.so
 
 all: $(BIN)
@@ -29,6 +30,9 @@ src/locate.o: src/locate.c src/locate.h src/memory.h
 	$(CC) $(CFLAGS) -c -o $@ $<
 
 src/memory.o: src/memory.c src/memory.h src/rdefs.h
+	$(CC) $(CFLAGS) -c -o $@ $<
+
+src/process.o: src/process.c
 	$(CC) $(CFLAGS) -c -o $@ $<
 
 src/xrprof.o: src/xrprof.c src/cursor.h

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -10,11 +10,11 @@ struct xrprof_cursor {
   void *rcxt_ptr;
   RCNTXT *cptr;
   struct libR_globals globals;
-  pid_t pid;
+  phandle pid;
   int depth;
 };
 
-struct xrprof_cursor *xrprof_create(pid_t pid) {
+struct xrprof_cursor *xrprof_create(phandle pid) {
   /* Find the symbols and addresses we need. */
   struct libR_globals globals;
   if (locate_libR_globals(pid, &globals) < 0) return NULL;

--- a/src/cursor.h
+++ b/src/cursor.h
@@ -1,11 +1,11 @@
 #ifndef XRPROF_CURSOR_H
 #define XRPROF_CURSOR_H
 
-#include <unistd.h> /* for pid_t */
+#include "process.h"
 
 struct xrprof_cursor;
 
-struct xrprof_cursor *xrprof_create(pid_t pid);
+struct xrprof_cursor *xrprof_create(phandle pid);
 void xrprof_destroy(struct xrprof_cursor *cursor);
 int xrprof_init(struct xrprof_cursor *cursor);
 

--- a/src/locate.c
+++ b/src/locate.c
@@ -208,7 +208,10 @@ int locate_libR_globals(phandle pid, struct libR_globals *out) {
       goto error;
     }
 
-    /* FIXME: Only select the module that looks like R. */
+    /* A module that looks like R. */
+    if (!strstr(mpath, "R.dll")) {
+      continue;
+    }
 
     base = SymLoadModuleEx(pid, NULL, mpath, NULL, (DWORD64) mods[i], 0, NULL, 0);
     if (!base) {

--- a/src/locate.c
+++ b/src/locate.c
@@ -183,6 +183,10 @@ int locate_libR_globals(phandle pid, struct libR_globals *out) {
 #include <dbghelp.h> /* for SymInitialize, SymLoadModuleEx, etc */
 
 int locate_libR_globals(phandle pid, struct libR_globals *out) {
+  if (proc_suspend(pid) < 0) {
+    return -1;
+  }
+
   /* TODO: Should we use TRUE here to force loading symbols from all modules? */
   if (!SymInitialize(pid, NULL, FALSE)) {
     fprintf(stderr, "error: Failed to load remote process symbols: %ld.\n",
@@ -306,10 +310,11 @@ remote process's memory. Are you sure it is an R program?\n");
   }
 
   SymCleanup(pid);
-  return 0;
+  return proc_resume(pid);
 
  error:
   SymCleanup(pid);
+  proc_resume(pid);
   return -1;
 }
 #else

--- a/src/locate.c
+++ b/src/locate.c
@@ -64,7 +64,7 @@ static int find_libR(pid_t pid, char **path, uintptr_t *addr) {
 }
 
 
-int locate_libR_globals(pid_t pid, struct libR_globals *out) {
+int locate_libR_globals(phandle pid, struct libR_globals *out) {
   /* Open the same libR.so in the tracer so we can determine the symbol offsets
      to read memory at in the tracee. */
 

--- a/src/locate.c
+++ b/src/locate.c
@@ -1,5 +1,6 @@
 #include <stdio.h>      /* for fprintf */
 #include "locate.h"
+#include "memory.h"
 
 #ifdef __linux
 #include <fcntl.h>      /* for open */
@@ -10,8 +11,6 @@
 #include <elf.h>
 #include <libelf.h>
 #include <gelf.h>
-
-#include "memory.h"
 
 #define MAX_LIBR_PATH_LEN 128
 
@@ -177,6 +176,138 @@ int locate_libR_globals(phandle pid, struct libR_globals *out) {
   }
 
   return 0;
+}
+#elif defined(__WIN32)
+#include <windows.h>
+#include <psapi.h> /* for EnumProcessModules */
+#include <dbghelp.h> /* for SymInitialize, SymLoadModuleEx, etc */
+
+int locate_libR_globals(phandle pid, struct libR_globals *out) {
+  /* TODO: Should we use TRUE here to force loading symbols from all modules? */
+  if (!SymInitialize(pid, NULL, FALSE)) {
+    fprintf(stderr, "error: Failed to load remote process symbols: %ld.\n",
+            GetLastError());
+    return -1;
+  }
+
+  HMODULE mods[1024];
+  DWORD mod_bytes;
+  if (!EnumProcessModules(pid, mods, sizeof(mods), &mod_bytes)) {
+    fprintf(stderr, "error: Failed to enumerate remote process modules: %ld.\n",
+            GetLastError());
+    goto error;
+  }
+  int entries = mod_bytes / sizeof(HMODULE);
+
+  TCHAR mpath[256];
+  DWORD64 base;
+  for (int i = 0; i < entries; i++ ) {
+    if (!GetModuleFileNameEx(pid, mods[i], mpath, sizeof(mpath) / sizeof(TCHAR))) {
+      fprintf(stderr, "error: Failed to get remote process module: %ld.\n",
+              GetLastError());
+      goto error;
+    }
+
+    /* FIXME: Only select the module that looks like R. */
+
+    base = SymLoadModuleEx(pid, NULL, mpath, NULL, (DWORD64) mods[i], 0, NULL, 0);
+    if (!base) {
+      fprintf(stderr, "error: Failed to load symbols for %s (0x%p): %ld.\n",
+              mpath, mods[i], GetLastError());
+      goto error;
+    }
+
+    uintptr_t value;
+    size_t bytes;
+    /* This is actually the crazy structure SymFromName uses. */
+    struct {
+      SYMBOL_INFO info;
+      char buf[MAX_SYM_NAME];
+    } info;
+    info.info.SizeOfStruct = sizeof(SYMBOL_INFO);
+    info.info.ModBase = base;
+    info.info.MaxNameLen = MAX_SYM_NAME - 1;
+    char *sym;
+
+    sym = "R_GlobalContext";
+    if (!SymFromName(pid, sym, &info.info)) {
+      if (GetLastError() != 123) {
+        fprintf(stderr, "error: Failed to lookup symbol: %ld.\n", GetLastError());
+        goto error;
+      }
+    } else {
+      out->context_addr = info.info.Address;
+    }
+
+    sym = "R_DoubleColonSymbol";
+    if (!SymFromName(pid, sym, &info.info)) {
+      if (GetLastError() != 123) {
+        fprintf(stderr, "error: Failed to lookup symbol: %ld.\n", GetLastError());
+        goto error;
+      }
+    } else {
+      /* copy_address() will print its own errors. */
+      bytes = copy_address(pid, (void *) info.info.Address, &value,
+                           sizeof(uintptr_t));
+      out->doublecolon = bytes < sizeof(uintptr_t) ? 0 : value;
+    }
+
+    sym = "R_TripleColonSymbol";
+    if (!SymFromName(pid, sym, &info.info)) {
+      if (GetLastError() != 123) {
+        fprintf(stderr, "error: Failed to lookup symbol: %ld.\n", GetLastError());
+        goto error;
+      }
+    } else {
+      bytes = copy_address(pid, (void *) info.info.Address, &value,
+                           sizeof(uintptr_t));
+      out->triplecolon = bytes < sizeof(uintptr_t) ? 0 : value;
+    }
+
+    sym = "R_DollarSymbol";
+    if (!SymFromName(pid, sym, &info.info)) {
+      if (GetLastError() != 123) {
+        fprintf(stderr, "error: Failed to lookup symbol: %ld.\n", GetLastError());
+        goto error;
+      }
+    } else {
+      bytes = copy_address(pid, (void *) info.info.Address, &value,
+                           sizeof(uintptr_t));
+      out->dollar = bytes < sizeof(uintptr_t) ? 0 : value;
+    }
+
+    sym = "R_BracketSymbol";
+    if (!SymFromName(pid, sym, &info.info)) {
+      if (GetLastError() != 123) {
+        fprintf(stderr, "error: Failed to lookup symbol: %ld.\n", GetLastError());
+        goto error;
+      }
+    } else {
+      bytes = copy_address(pid, (void *) info.info.Address, &value,
+                           sizeof(uintptr_t));
+      out->bracket = bytes < sizeof(uintptr_t) ? 0 : value;
+    }
+
+    if (!SymUnloadModule64(pid, base)) {
+      fprintf(stderr, "error: Failed to unload symbols for %s (0x%p): %ld.\n",
+              mpath, mods[i], GetLastError());
+      goto error;
+    }
+  }
+
+  if (!out->doublecolon || !out->triplecolon || !out->dollar || !out->bracket ||
+      !out->context_addr) {
+    fprintf(stderr, "error: Failed to locate required R global variables in \
+remote process's memory. Are you sure it is an R program?\n");
+    goto error;
+  }
+
+  SymCleanup(pid);
+  return 0;
+
+ error:
+  SymCleanup(pid);
+  return -1;
 }
 #else
 #error "No support for non-Linux platforms."

--- a/src/locate.c
+++ b/src/locate.c
@@ -1,6 +1,9 @@
+#include <stdio.h>      /* for fprintf */
+#include "locate.h"
+
+#ifdef __linux
 #include <fcntl.h>      /* for open */
 #include <stddef.h>     /* for ptrdiff_t */
-#include <stdio.h>      /* for fprintf */
 #include <stdlib.h>     /* for malloc */
 #include <string.h>     /* for strstr, strndup */
 
@@ -8,7 +11,6 @@
 #include <libelf.h>
 #include <gelf.h>
 
-#include "locate.h"
 #include "memory.h"
 
 #define MAX_LIBR_PATH_LEN 128
@@ -176,3 +178,6 @@ int locate_libR_globals(phandle pid, struct libR_globals *out) {
 
   return 0;
 }
+#else
+#error "No support for non-Linux platforms."
+#endif

--- a/src/locate.h
+++ b/src/locate.h
@@ -2,7 +2,7 @@
 #define XRPROF_LOCATE_H
 
 #include <stdint.h> /* for uintptr_t */
-#include <unistd.h> /* for pid_t */
+#include "process.h"
 
 struct libR_globals {
   uintptr_t context_addr;
@@ -12,6 +12,6 @@ struct libR_globals {
   uintptr_t bracket;
 };
 
-int locate_libR_globals(pid_t pid, struct libR_globals *out);
+int locate_libR_globals(phandle pid, struct libR_globals *out);
 
 #endif /* XRPROF_LOCATE_H */

--- a/src/memory.c
+++ b/src/memory.c
@@ -1,9 +1,23 @@
 #ifdef __linux
 #define _GNU_SOURCE  /* for process_vm_readv */
+#endif
+
 #include <stdio.h>   /* for fprintf, perror, stderr */
+
+#include "memory.h"
+#include "rdefs.h"
+
+#ifdef __linux
 #include <sys/uio.h> /* for iovec, process_vm_readv */
 
-size_t copy_address(pid_t pid, void *addr, void *data, size_t len) {
+/* No-op on Linux. */
+int phandle_init(phandle *out, void *data) {
+  pid_t pid = *((pid_t *) data);
+  *out = pid;
+  return 0;
+}
+
+size_t copy_address(phandle pid, void *addr, void *data, size_t len) {
   struct iovec local[1];
   local[0].iov_base = data;
   local[0].iov_len = len;
@@ -24,9 +38,7 @@ size_t copy_address(pid_t pid, void *addr, void *data, size_t len) {
 #error "No support for non-Linux platforms."
 #endif
 
-#include "rdefs.h"
-
-int copy_context(pid_t pid, void *addr, RCNTXT *data) {
+int copy_context(phandle pid, void *addr, RCNTXT *data) {
   if (!addr) {
     return -1;
   }
@@ -40,7 +52,7 @@ int copy_context(pid_t pid, void *addr, RCNTXT *data) {
   return 0;
 }
 
-int copy_sexp(pid_t pid, void *addr, SEXP data) {
+int copy_sexp(phandle pid, void *addr, SEXP data) {
   if (!addr) {
     return -1;
   }
@@ -54,7 +66,7 @@ int copy_sexp(pid_t pid, void *addr, SEXP data) {
   return 0;
 }
 
-int copy_char(pid_t pid, void *addr, char *data, size_t max_len) {
+int copy_char(phandle pid, void *addr, char *data, size_t max_len) {
   if (!addr) {
     return -1;
   }

--- a/src/memory.c
+++ b/src/memory.c
@@ -34,8 +34,19 @@ size_t copy_address(phandle pid, void *addr, void *data, size_t len) {
   }
   return bytes;
 }
+#elif defined(__WIN32)
+#include <windows.h> /* for ReadProcessMemory, GetLastError */
+
+size_t copy_address(phandle pid, void *addr, void *data, size_t len) {
+  if (!ReadProcessMemory(pid, addr, data, len, NULL)) {
+    fprintf(stderr, "error: Failed to read memory in the remote process: %ld.\n",
+            GetLastError());
+    return -1;
+  }
+  return len;
+}
 #else
-#error "No support for non-Linux platforms."
+#error "No support for this platform."
 #endif
 
 int copy_context(phandle pid, void *addr, RCNTXT *data) {

--- a/src/memory.h
+++ b/src/memory.h
@@ -1,12 +1,12 @@
 #ifndef XRPROF_MEMORY_H
 #define XRPROF_MEMORY_H
 
-#include <unistd.h> /* for pid_t */
+#include "process.h" /* for phandle */
 #include "rdefs.h"  /* for RCNTXT, SEXP */
 
-size_t copy_address(pid_t pid, void *addr, void *data, size_t len);
-int copy_context(pid_t pid, void *addr, RCNTXT *data);
-int copy_sexp(pid_t pid, void *addr, SEXP data);
-int copy_char(pid_t pid, void *addr, char *data, size_t max_len);
+size_t copy_address(phandle pid, void *addr, void *data, size_t len);
+int copy_context(phandle pid, void *addr, RCNTXT *data);
+int copy_sexp(phandle pid, void *addr, SEXP data);
+int copy_char(phandle pid, void *addr, char *data, size_t max_len);
 
 #endif /* XRPROF_MEMORY_H */

--- a/src/process.c
+++ b/src/process.c
@@ -61,6 +61,37 @@ int proc_destroy(phandle pid) {
   ptrace(PTRACE_DETACH, pid, NULL, NULL);
   return 0;
 }
+#elif defined(__WIN32)
+#include <unistd.h>  /* for pid_t */
+#include <windows.h>
+
+int proc_create(phandle *out, void *data) {
+  pid_t pid = *((pid_t *) data);
+  *out = OpenProcess(PROCESS_VM_READ, FALSE, pid);
+  if (!*out) {
+    fprintf(stderr, "error: Failed to open process %I64d: %ld.\n", pid,
+            GetLastError());
+    return -1;
+  }
+  return 0;
+}
+
+int proc_suspend(phandle pid) {
+  return 0;
+}
+
+int proc_resume(phandle pid) {
+  return 0;
+}
+
+int proc_destroy(phandle pid) {
+  BOOL ret = CloseHandle(pid);
+  if (ret == FALSE) {
+    fprintf(stderr, "Failed to close process handle: %ld.\n", GetLastError());
+    return -1;
+  }
+  return 0;
+}
 #else
 #error "No support for non-Linux platforms."
 #endif

--- a/src/process.c
+++ b/src/process.c
@@ -1,0 +1,66 @@
+#include <stdio.h>      /* for fprintf */
+
+#include "process.h"
+
+#ifdef __linux
+#include <sys/ptrace.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+
+int proc_create(phandle *out, void *data) {
+  pid_t *pid = (pid_t *) data;
+  *out = *pid;
+  if (ptrace(PTRACE_SEIZE, *out, NULL, NULL)) {
+    perror("fatal: Failed to attach to remote process");
+    return -1;
+  }
+  return 0;
+}
+
+int proc_suspend(phandle pid) {
+  if (ptrace(PTRACE_INTERRUPT, pid, NULL, NULL)) {
+    perror("fatal: Failed to interrupt remote process");
+    return -1;
+  }
+
+  int wstatus;
+  if (waitpid(pid, &wstatus, 0) < 0) {
+    perror("fatal: Failed to obtain remote process status information");
+    return -1;
+  }
+  if (WIFEXITED(wstatus)) {
+    fprintf(stderr, "Process %d finished.\n", pid);
+    return -2;
+  } else if (WIFSTOPPED(wstatus) && WSTOPSIG(wstatus) == SIGCHLD) {
+    /* Try again. */
+    ptrace(PTRACE_CONT, pid, NULL, NULL);
+    return proc_suspend(pid);
+  } else if (WIFSTOPPED(wstatus) && WSTOPSIG(wstatus) != SIGTRAP) {
+    fprintf(stderr, "fatal: Unexpected stop signal in remote process: %d.\n",
+            WSTOPSIG(wstatus));
+    return -1;
+  } else if (!WIFSTOPPED(wstatus)) {
+    fprintf(stderr, "fatal: Unexpected remote process status: %d.\n",
+            WSTOPSIG(wstatus));
+    return -1;
+  }
+
+  return 0;
+}
+
+int proc_resume(phandle pid) {
+  if (ptrace(PTRACE_CONT, pid, NULL, NULL)) {
+    perror("fatal: Failed to continue remote process");
+    return -1;
+  }
+  return 0;
+}
+
+int proc_destroy(phandle pid) {
+  /* We don't actually care if this succeeds or not. */
+  ptrace(PTRACE_DETACH, pid, NULL, NULL);
+  return 0;
+}
+#else
+#error "No support for non-Linux platforms."
+#endif

--- a/src/process.c
+++ b/src/process.c
@@ -73,7 +73,8 @@ LONG NtResumeProcess(IN HANDLE ProcessHandle);
 
 int proc_create(phandle *out, void *data) {
   pid_t pid = *((pid_t *) data);
-  *out = OpenProcess(PROCESS_VM_READ | PROCESS_SUSPEND_RESUME, FALSE, pid);
+  *out = OpenProcess(PROCESS_VM_READ | PROCESS_SUSPEND_RESUME |
+                     PROCESS_QUERY_INFORMATION, FALSE, pid);
   if (!*out) {
     fprintf(stderr, "error: Failed to open process %I64d: %ld.\n", pid,
             GetLastError());

--- a/src/process.c
+++ b/src/process.c
@@ -86,6 +86,10 @@ int proc_create(phandle *out, void *data) {
 
 int proc_suspend(phandle pid) {
   NTSTATUS ret = NtSuspendProcess(pid);
+  if (ret == 0XC000010A) {
+    fprintf(stderr, "Process finished.\n");
+    return -2;
+  }
   if (ret == 0XC0000002) {
     /* Running under Wine. */
     fprintf(stderr, "warning: Process cannot be suspended/resumed (%#lX).\n",

--- a/src/process.c
+++ b/src/process.c
@@ -86,6 +86,12 @@ int proc_create(phandle *out, void *data) {
 
 int proc_suspend(phandle pid) {
   NTSTATUS ret = NtSuspendProcess(pid);
+  if (ret == 0XC0000002) {
+    /* Running under Wine. */
+    fprintf(stderr, "warning: Process cannot be suspended/resumed (%#lX).\n",
+            ret);
+    return 0;
+  }
   if (ret != 0) {
     fprintf(stderr, "error: Failed to suspend process: %ld (%#lX).\n",
             RtlNtStatusToDosError(ret), ret);
@@ -96,6 +102,12 @@ int proc_suspend(phandle pid) {
 
 int proc_resume(phandle pid) {
   NTSTATUS ret = NtResumeProcess(pid);
+  if (ret == 0XC0000002) {
+    /* Running under Wine. */
+    fprintf(stderr, "warning: Process cannot be suspended/resumed (%#lX).\n",
+            ret);
+    return 0;
+  }
   if (ret != 0) {
     fprintf(stderr, "error: Failed to resume process: %ld (%#lX).\n",
             RtlNtStatusToDosError(ret), ret);

--- a/src/process.c
+++ b/src/process.c
@@ -64,6 +64,7 @@ int proc_destroy(phandle pid) {
 #elif defined(__WIN32)
 #include <unistd.h>  /* for pid_t */
 #include <windows.h>
+#include <winternl.h>
 
 /* The internal APIs that everyone seems to use from ntdll:
    https://stackoverflow.com/questions/11010165/how-to-suspend-resume-a-process-in-windows/11010508#11010508
@@ -84,16 +85,20 @@ int proc_create(phandle *out, void *data) {
 }
 
 int proc_suspend(phandle pid) {
-  if (NtSuspendProcess(pid) != 0) {
-    fprintf(stderr, "error: Failed to suspend process: %ld.\n", GetLastError());
+  NTSTATUS ret = NtSuspendProcess(pid);
+  if (ret != 0) {
+    fprintf(stderr, "error: Failed to suspend process: %ld (%#lX).\n",
+            RtlNtStatusToDosError(ret), ret);
     return -1;
   }
   return 0;
 }
 
 int proc_resume(phandle pid) {
-  if (NtResumeProcess(pid) != 0) {
-    fprintf(stderr, "error: Failed to resume process: %ld.\n", GetLastError());
+  NTSTATUS ret = NtResumeProcess(pid);
+  if (ret != 0) {
+    fprintf(stderr, "error: Failed to resume process: %ld (%#lX).\n",
+            RtlNtStatusToDosError(ret), ret);
     return -1;
   }
   return 0;

--- a/src/process.h
+++ b/src/process.h
@@ -1,0 +1,16 @@
+#ifndef XRPROF_PROCESS_H
+#define XRPROF_PROCESS_H
+
+#ifdef __unix
+#include <unistd.h>  /* for pid_t */
+typedef pid_t phandle;
+#else
+#error "No support for this platform."
+#endif
+
+int proc_create(phandle *out, void *data);
+int proc_suspend(phandle pid);
+int proc_resume(phandle pid);
+int proc_destroy(phandle pid);
+
+#endif /* XRPROF_PROCESS_H */

--- a/src/process.h
+++ b/src/process.h
@@ -1,7 +1,9 @@
 #ifndef XRPROF_PROCESS_H
 #define XRPROF_PROCESS_H
 
-#ifdef __unix
+#ifdef __WIN32
+typedef void * phandle;
+#elif defined(__unix)
 #include <unistd.h>  /* for pid_t */
 typedef pid_t phandle;
 #else

--- a/src/xrprof.c
+++ b/src/xrprof.c
@@ -8,6 +8,10 @@
 #include <unistd.h>
 #include <time.h>    /* for timespec */
 
+#ifdef __MINGW
+#include <pthreads.h> /* for nanosleep */
+#endif
+
 #ifdef __linux
 #define HAVE_LIBUNWIND
 #include <libunwind-ptrace.h>

--- a/src/xrprof.c
+++ b/src/xrprof.c
@@ -35,6 +35,23 @@ int install_ctrl_c_handler() {
   signal(SIGINT, handle_sigint);
   return 0;
 }
+#elif defined(__WIN32)
+#include <windows.h>  /* for BOOL, DWORD, SetConsoleCtrlHandler, TRUE */
+
+BOOL handle_signal(DWORD signal) {
+  if (signal == CTRL_C_EVENT) {
+    should_trace = 0;
+  }
+  return TRUE;
+}
+
+int install_ctrl_c_handler() {
+  if (!SetConsoleCtrlHandler(handle_signal, TRUE)) {
+    fprintf(stderr, "error: Could not set console control handler.\n");
+    return -1;
+  }
+  return 0;
+}
 #else
 int install_ctrl_c_handler() {
   return 0;

--- a/src/xrprof.c
+++ b/src/xrprof.c
@@ -24,10 +24,24 @@
 #define DEFAULT_DURATION 3600 // One hour.
 
 static volatile int should_trace = 1;
+int install_ctrl_c_handler();
+
+#ifdef __unix
+#include <signal.h>
 
 void handle_sigint(int _sig) {
   should_trace = 0;
 }
+
+int install_ctrl_c_handler() {
+  signal(SIGINT, handle_sigint);
+  return 0;
+}
+#else
+int install_ctrl_c_handler() {
+  return 0;
+}
+#endif
 
 void usage(const char *name) {
   // TODO: Add a long help message.
@@ -143,7 +157,10 @@ int main(int argc, char **argv) {
   /* Stop the tracee and read the R stack information. */
 
   // Allow the user to stop the tracing with Ctrl-C.
-  signal(SIGINT, handle_sigint);
+  if ((code = install_ctrl_c_handler()) < 0) {
+    return -code;
+  }
+
   float elapsed = 0;
 
   // Write the Rprof.out header.

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,6 +1,7 @@
 TEST_PROFILES := sleep.out
 BIN = ../xrprof
 RSCRIPT = Rscript
+SUDO = sudo
 
 all: $(TEST_PROFILES)
 
@@ -9,6 +10,6 @@ clean:
 
 %.out: %.R
 	echo $(BIN)
-	sudo BIN=$(BIN) RSCRIPT=$(RSCRIPT) ./harness.sh $<
+	$(SUDO) BIN=$(BIN) ./harness.sh $<
 
 .PHONY: all clean

--- a/tests/harness.sh
+++ b/tests/harness.sh
@@ -46,3 +46,7 @@ if [ ! -z "$SUDO_USER" ]; then
     # Ensure we can actually look at the output.
     chown $SUDO_USER:$SUDO_USER $OUTFILE
 fi
+
+LINES=`wc -l $OUTFILE | cut -d ' ' -f 1`
+echo "--- $OUTFILE ($LINES lines):"
+head $OUTFILE

--- a/tests/harness.sh
+++ b/tests/harness.sh
@@ -26,6 +26,11 @@ set -e
 if [ -z "$SUDO_USER" ]; then
     $RSCRIPT $TEST &
     PID=$!
+    # Try to detect Cygwin. Unixy PIDs will not work for OpenProcess().
+    WINPID=`cat /proc/$PID/winpid || true`
+    if [ ! -z "$WINPID" ]; then
+        PID=$WINPID
+    fi
 else
     # Run the script as the original sudo user (i.e. not root), so that it
     # behaves as expected.

--- a/tests/harness.sh
+++ b/tests/harness.sh
@@ -23,12 +23,21 @@ fi
 
 set -e
 
-# Run the script as the original sudo user (i.e. not root), wait a little bit
-# for the fork(s), and then start profiling.
-sudo -u $SUDO_USER $RSCRIPT $TEST &
-sleep 0.25
-PID=`ps --ppid $! -o pid=`
+if [ -z "$SUDO_USER" ]; then
+    $RSCRIPT $TEST &
+    PID=$!
+else
+    # Run the script as the original sudo user (i.e. not root), so that it
+    # behaves as expected.
+    sudo -u $SUDO_USER $RSCRIPT $TEST &
+    # Wait a little bit for the fork(s).
+    sleep 0.25
+    PID=`ps --ppid $! -o pid=`
+fi
+
 $BIN -F 50 $@ -p $PID > $OUTFILE
 
-# Ensure we can actually look at the output.
-chown $SUDO_USER:$SUDO_USER $OUTFILE
+if [ ! -z "$SUDO_USER" ]; then
+    # Ensure we can actually look at the output.
+    chown $SUDO_USER:$SUDO_USER $OUTFILE
+fi


### PR DESCRIPTION
This PR does the following:

* Ports reading memory, suspending/resuming processes, and looking up R's symbols to Windows APIs. This required some internal refactoring and abstraction. The project now compiles under MinGW:

```console
$ make BIN=xrprof.exe LIBS="-lntdll -lpsapi -ldbghelp -lpthread -static"
```

* Adds Windows to the Travis CI build matrix.
* Adds various features to the `Makefile` and the test `harness.sh` to allow for running the tests under Cygwin (as Travis CI does).

Known issues:

* Samples cannot seem to resolve R's symbols -- they show up as `<Unknown>`.
* Mixed-mode profiling is not yet implemented.

Most of #3.