### PR TITLE
Have process_vm_readv return a ssize_t, not a size_t

### DIFF
--- a/src/memory.c
+++ b/src/memory.c
@@ -26,7 +26,7 @@ size_t copy_address(phandle pid, void *addr, void *data, size_t len) {
   remote[0].iov_base = addr;
   remote[0].iov_len = len;
 
-  size_t bytes = process_vm_readv(pid, local, 1, remote, 1, 0);
+  ssize_t bytes = process_vm_readv(pid, local, 1, remote, 1, 0);
   if (bytes < 0) {
     perror("error: Failed to read memory in the remote process");
   } else if (bytes < len) {


### PR DESCRIPTION
size_t are unsigned integers, so they by definition cannot hold values
less than 0.