### PR TITLE
allow prefix to be overridden on the command-line

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ test: $(BIN)
 
 # Mostly compatible with https://www.gnu.org/prep/standards/html_node/Makefile-Conventions.html
 INSTALL = install
-prefix = /usr/local
+prefix ?= /usr/local
 bindir = $(prefix)/bin
 datadir = $(prefix)/share
 includedir = $(prefix)/include


### PR DESCRIPTION
Currently `Makefile` hard-code `prefix` to `/usr/local` which is incompatible with how distributions package content.  Switching the assignment to `?=` lets the current behaviour (of using `/usr/local` by default) to continue yet permits setting an override.

A simple demo using a (not-committed) `make` target that just echos the value:

```sh
edd@rob:~/git/xrprof(master)$ make -n showprefix
echo "Prefix is /usr/local"
edd@rob:~/git/xrprof(master)$ make -n showprefix prefix=/tmp
echo "Prefix is /tmp"
edd@rob:~/git/xrprof(master)$ 
```