### PR TITLE
Increase symbol buffer size to 1024 bytes (closes #27)

### DIFF
--- a/src/xrprof.c
+++ b/src/xrprof.c
@@ -217,7 +217,7 @@ int main(int argc, char **argv) {
       code++;
       goto done;
     } else if (mixed_mode) {
-      char sym[256];
+      char sym[1024];
       unw_word_t offset, ip;
       unw_proc_info_t info;
 


### PR DESCRIPTION
As discussed in #27 this addresses an issue seen where symbol length was larger than was the buffer allowed for.